### PR TITLE
Add va_end to variadic functions.

### DIFF
--- a/src/libiff/error.c
+++ b/src/libiff/error.c
@@ -35,6 +35,7 @@ void IFF_error(const char *formatString, ...)
     
     va_start(ap, formatString);
     IFF_errorCallback(formatString, ap);
+    va_end(ap);
 }
 
 void IFF_errorId(const IFF_ID id)

--- a/src/libiff/util.c
+++ b/src/libiff/util.c
@@ -33,4 +33,5 @@ void IFF_printIndent(FILE *file, const unsigned int indentLevel, const char *for
       fprintf(file, "  ");
     
     vfprintf(file, formatString, ap);
+    va_end(ap);
 }


### PR DESCRIPTION
From the BSD man page (On Mac OS X):
> Note that each call to va_start() must be matched by a call to va_end(), from within the same function.
