### PR TITLE
Fix man page dependency chain

### DIFF
--- a/src/iffjoin/Makefile.am
+++ b/src/iffjoin/Makefile.am
@@ -1,4 +1,4 @@
-iffjoin.1: main.c
+iffjoin.1: iffjoin
 	$(HELP2MAN) --output=$@ --no-info --name 'Joins an arbitrary number of IFF files into a single concatenation IFF file' --libtool ./iffjoin
 
 AM_CPPFLAGS = -DHAVE_GETOPT_H=$(HAVE_GETOPT_H)

--- a/src/iffpp/Makefile.am
+++ b/src/iffpp/Makefile.am
@@ -1,4 +1,4 @@
-iffpp.1: main.c
+iffpp.1: iffpp
 	$(HELP2MAN) --output=$@ --no-info --name 'IFF pretty printer' --libtool ./iffpp
 
 AM_CPPFLAGS = -DHAVE_GETOPT_H=$(HAVE_GETOPT_H)


### PR DESCRIPTION
The man pages were failing to build when using `make -j8` or any more jobs than that.

This fixes that.